### PR TITLE
Set persistent message if no temporary message expiration

### DIFF
--- a/custom_components/vestaboard/coordinator.py
+++ b/custom_components/vestaboard/coordinator.py
@@ -109,7 +109,7 @@ class VestaboardCoordinator(DataUpdateCoordinator):
         if data is None:
             raise ConfigEntryAuthFailed
 
-        if self.persistent_message is None:
+        if self.temporary_message_expiration is None:
             self.persistent_message = data
 
         return await self.hass.async_add_executor_job(self.process_data, data)


### PR DESCRIPTION
Fixes #84 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed temporary messages being incorrectly saved as persistent messages.
  * Ensured persistent content is preserved after temporary message updates expire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->